### PR TITLE
出欠受付状況の管理画面を作成

### DIFF
--- a/app/controllers/admin/attendances_controller.rb
+++ b/app/controllers/admin/attendances_controller.rb
@@ -184,4 +184,44 @@ class Admin::AttendancesController < Admin::BaseController
     end
     redirect_to admin_attendance_path, notice: "#{update_count}人の出席状況を更新しました"
   end
+
+  def status
+    # 出欠受付管理画面用のデータを取得
+    @attendance_events = AttendanceEvent.order(date: :desc)
+    @competitions = Competition.order(date: :desc)
+  end
+
+  def update_status
+    begin
+      ActiveRecord::Base.transaction do
+        # AttendanceEventの更新
+        if params[:attendance_events].present?
+          params[:attendance_events].each do |event_id, status|
+            event = AttendanceEvent.find(event_id)
+            event.update!(attendance_status: status)
+          end
+        end
+
+        # Competitionの更新
+        if params[:competitions].present?
+          params[:competitions].each do |event_id, status|
+            event = Competition.find(event_id)
+            event.update!(attendance_status: status)
+          end
+        end
+
+        if request.format.json? || request.content_type == 'application/json'
+          render json: { success: true, message: "出欠受付状況を更新しました" }
+        else
+          redirect_to admin_attendance_status_path, notice: "出欠受付状況を更新しました"
+        end
+      end
+    rescue => e
+      if request.format.json? || request.content_type == 'application/json'
+        render json: { success: false, message: "更新中にエラーが発生しました: #{e.message}" }
+      else
+        redirect_to admin_attendance_status_path, alert: "更新中にエラーが発生しました: #{e.message}"
+      end
+    end
+  end
 end 

--- a/app/models/attendance_event.rb
+++ b/app/models/attendance_event.rb
@@ -12,8 +12,8 @@ class AttendanceEvent < Event
 
   enum :attendance_status, {
     before: 0,  # 出欠集計前
-    open: 1,    # 集計中
-    closed: 2   # 集計済み
+    open: 1,    # 受付中
+    closed: 2   # 受付終了
   }, prefix: :attendance
 
   # デフォルト値設定（バリデーション前）

--- a/app/views/admin/attendances/index.html.erb
+++ b/app/views/admin/attendances/index.html.erb
@@ -28,6 +28,17 @@
     </div>
   </div>
 
+  <!-- 出欠受付管理 -->
+  <div class="bg-white rounded-xl shadow-sm border border-gray-100 mb-8">
+    <div class="p-6 border-b border-gray-200">
+      <h2 class="text-xl font-semibold text-gray-900 mb-4">出欠受付管理</h2>
+      <p class="text-sm text-gray-600 mb-4">イベントの出欠受付状況を管理できます</p>
+      <%= link_to admin_attendance_status_path, class: "bg-blue-600 text-white px-4 py-2 rounded-md text-sm font-medium hover:bg-blue-700 transition-colors" do %>
+        出欠受付管理
+      <% end %>
+    </div>
+  </div>
+
   <!-- 月別出欠状況 -->
   <div class="bg-white rounded-xl shadow-sm border border-gray-100 mb-8">
     <div class="p-6 border-b border-gray-200">
@@ -49,25 +60,25 @@
       </div>
     </div>
 
-      <div class="overflow-x-auto border border-gray-300">
+      <div class="overflow-x-auto border border-gray-300" style="max-width: 100%;">
        <% if @monthly_events.any? %>
-         <table class="w-full min-w-full border-collapse">
+         <table class="border-collapse" style="min-width: max-content;">
            <thead class="bg-gray-50">
              <tr>
-               <th class="px-2 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider sticky left-0 bg-gray-50 w-24 border border-gray-300" style="z-index: 10;">
+               <th class="px-2 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider sticky left-0 bg-gray-50 border border-gray-300" style="z-index: 20; width: 100px; min-width: 100px;">
                  部員名
                </th>
-               <th class="px-2 py-2 text-center text-xs font-medium text-gray-500 uppercase tracking-wider sticky bg-gray-50 w-16 border border-gray-300" style="left: 96px; z-index: 10;">
+               <th class="px-2 py-2 text-center text-xs font-medium text-gray-500 uppercase tracking-wider sticky bg-gray-50 border border-gray-300" style="left: 100px; z-index: 20; width: 70px; min-width: 70px;">
                  総出席日数
                </th>
-               <th class="px-2 py-2 text-center text-xs font-medium text-gray-500 uppercase tracking-wider sticky bg-gray-50 w-16 border border-gray-300 cursor-pointer hover:bg-gray-200" style="left: 160px; z-index: 10;" data-sort-by="attendance_rate">
+               <th class="px-2 py-2 text-center text-xs font-medium text-gray-500 uppercase tracking-wider sticky bg-gray-50 border border-gray-300 cursor-pointer hover:bg-gray-200" style="left: 170px; z-index: 20; width: 70px; min-width: 70px;" data-sort-by="attendance_rate">
                  出席率
                  <% if @sort_by == 'attendance_rate' %>
                    <span class="ml-1 text-xs">▼</span>
                  <% end %>
                </th>
                <% @monthly_events.each do |event| %>
-                 <th class="px-1 py-2 text-center text-xs font-medium text-gray-500 uppercase tracking-wider w-12 border border-gray-300">
+                 <th class="px-1 py-2 text-center text-xs font-medium text-gray-500 uppercase tracking-wider border border-gray-300" style="z-index: 10; width: 40px; min-width: 40px;">
                    <div class="whitespace-nowrap text-xs">
                      <%= event.date.strftime("%d") %>
                    </div>
@@ -86,7 +97,7 @@
                  attendance_rate = total_events > 0 ? (present_count.to_f / total_events * 100).round(1) : 0
                %>
                <tr class="hover:bg-gray-50">
-                 <td class="px-2 py-2 whitespace-nowrap text-xs font-medium text-gray-900 sticky left-0 bg-white z-10 w-24 border border-gray-300">
+                 <td class="px-2 py-2 whitespace-nowrap text-xs font-medium text-gray-900 sticky left-0 bg-white z-20 border border-gray-300" style="width: 100px; min-width: 100px;">
                    <div class="flex items-center">
                      <div>
                        <div class="font-medium text-xs"><%= user.name %></div>
@@ -94,18 +105,18 @@
                      </div>
                    </div>
                  </td>
-                 <td class="px-2 py-2 whitespace-nowrap text-center text-xs sticky bg-white z-10 w-16 border border-gray-300" style="left: 96px;">
+                 <td class="px-2 py-2 whitespace-nowrap text-center text-xs sticky bg-white z-20 border border-gray-300" style="left: 100px; width: 70px; min-width: 70px;">
                    <span class="font-semibold text-blue-600 text-xs"><%= present_count %></span>
                    <span class="text-gray-500 text-xs">/<%= total_events %></span>
                  </td>
-                 <td class="px-2 py-2 whitespace-nowrap text-center text-xs sticky bg-white z-10 w-16 border border-gray-300" style="left: 160px;">
+                 <td class="px-2 py-2 whitespace-nowrap text-center text-xs sticky bg-white z-20 border border-gray-300" style="left: 170px; width: 70px; min-width: 70px;">
                    <span class="font-semibold text-xs <%= attendance_rate >= 80 ? 'text-green-600' : attendance_rate >= 60 ? 'text-yellow-600' : 'text-red-600' %>">
                      <%= attendance_rate %>%
                    </span>
                  </td>
                  <% @monthly_events.each do |event| %>
                    <% status = @monthly_attendance_data[user.id][event.id] %>
-                   <td class="px-1 py-2 whitespace-nowrap text-center text-xs border border-gray-300">
+                   <td class="px-1 py-2 whitespace-nowrap text-center text-xs border border-gray-300" style="z-index: 10; width: 40px; min-width: 40px;">
                      <% case status %>
                      <% when 'present' %>
                        <span class="inline-flex items-center justify-center w-4 h-4 rounded-full bg-green-100 text-green-800 text-xs font-bold">

--- a/app/views/admin/attendances/status.html.erb
+++ b/app/views/admin/attendances/status.html.erb
@@ -1,0 +1,374 @@
+<% content_for :title, '出欠受付管理' %>
+
+<div class="w-full pt-8">
+  <div class="text-center mb-8">
+    <h1 class="text-4xl font-bold text-gray-900 mb-3">出欠受付管理</h1>
+    <p class="text-lg text-gray-600">イベントの出欠受付状況を管理できます</p>
+  </div>
+
+  <% if flash[:notice] %>
+    <div class="mb-6 bg-green-50 p-4 rounded-lg">
+      <div class="flex">
+        <div class="flex-shrink-0">
+          <svg class="h-5 w-5 text-green-400" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+          </svg>
+        </div>
+        <div class="ml-3">
+          <p class="text-sm font-medium text-green-800"><%= flash[:notice] %></p>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
+  <% if flash[:alert] %>
+    <div class="mb-6 bg-red-50 p-4 rounded-lg">
+      <div class="flex">
+        <div class="flex-shrink-0">
+          <svg class="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
+          </svg>
+        </div>
+        <div class="ml-3">
+          <p class="text-sm font-medium text-red-800"><%= flash[:alert] %></p>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
+    <!-- イベントの出欠受付管理 -->
+    <div class="bg-white rounded-xl shadow-sm border border-gray-100 mb-8">
+      <div class="p-6 border-b border-gray-200">
+        <h2 class="text-xl font-semibold text-gray-900 mb-4">イベントの出欠受付管理</h2>
+        <p class="text-sm text-gray-600 mb-4">練習、イベント、大会の出欠受付状況を設定できます</p>
+        
+        <!-- フィルタリング機能 -->
+        <div class="bg-gray-50 p-4 rounded-lg mb-4">
+          <h3 class="text-sm font-medium text-gray-700 mb-3">フィルタリング</h3>
+          <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+            <!-- イベントタイプフィルター -->
+            <div>
+              <label for="event-type-filter" class="block text-xs font-medium text-gray-600 mb-1">イベントタイプ</label>
+              <select id="event-type-filter" class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <option value="">全て</option>
+                <option value="attendance_event">練習・ミーティング</option>
+                <option value="competition">大会</option>
+              </select>
+            </div>
+            
+            <!-- 年フィルター -->
+            <div>
+              <label for="year-filter" class="block text-xs font-medium text-gray-600 mb-1">年</label>
+              <select id="year-filter" class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <option value="">全て</option>
+                <% (Date.current.year - 2..Date.current.year + 1).each do |year| %>
+                  <option value="<%= year %>" <%= 'selected' if year == Date.current.year %>><%= year %>年</option>
+                <% end %>
+              </select>
+            </div>
+            
+            <!-- 月フィルター -->
+            <div>
+              <label for="month-filter" class="block text-xs font-medium text-gray-600 mb-1">月</label>
+              <select id="month-filter" class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <option value="">全て</option>
+                <% (1..12).each do |month| %>
+                  <option value="<%= month %>"><%= month %>月</option>
+                <% end %>
+              </select>
+            </div>
+            
+            <!-- 出欠受付状況フィルター -->
+            <div>
+              <label for="status-filter" class="block text-xs font-medium text-gray-600 mb-1">出欠受付状況</label>
+              <select id="status-filter" class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <option value="">全て</option>
+                <option value="before">出欠集計前</option>
+                <option value="open">受付中</option>
+                <option value="closed">受付終了</option>
+              </select>
+            </div>
+          </div>
+          
+          <!-- フィルターリセットボタン -->
+          <div class="mt-3">
+            <button type="button" id="reset-filters-btn" class="text-sm text-gray-600 hover:text-gray-800 underline">
+              フィルターをリセット
+            </button>
+          </div>
+        </div>
+
+        <!-- 一括変更機能 -->
+        <div class="flex items-center space-x-4 mb-4">
+          <div class="flex items-center space-x-2">
+            <label for="bulk-status" class="text-sm font-medium text-gray-700">選択したイベントを一括で:</label>
+            <select id="bulk-status" class="border border-gray-300 rounded-md px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+              <option value="">変更先を選択</option>
+              <option value="before">出欠集計前</option>
+              <option value="open">受付中</option>
+              <option value="closed">受付終了</option>
+            </select>
+            <button type="button" id="bulk-update-btn" class="bg-blue-600 text-white px-3 py-1 rounded-md text-sm font-medium hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed" disabled>
+              一括変更
+            </button>
+          </div>
+        </div>
+      </div>
+      
+      <div class="p-6">
+        <% if @attendance_events.any? || @competitions.any? %>
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-12">
+                    <input type="checkbox" id="select-all-header" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+                  </th>
+                  <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">日付</th>
+                  <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">タイトル</th>
+                  <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">大会</th>
+                  <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">場所</th>
+                  <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">出欠受付状況</th>
+                </tr>
+              </thead>
+              <tbody class="bg-white divide-y divide-gray-200">
+                <% (@attendance_events + @competitions).sort_by(&:date).reverse.each do |event| %>
+                  <tr class="event-row hover:bg-gray-50" 
+                      data-event-type="<%= event.is_a?(Competition) ? 'competition' : 'attendance_event' %>"
+                      data-event-month="<%= event.date.month %>"
+                      data-event-year="<%= event.date.year %>"
+                      data-event-status="<%= event.attendance_status %>">
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      <input type="checkbox" 
+                             class="event-checkbox rounded border-gray-300 text-blue-600 focus:ring-blue-500" 
+                             data-event-id="<%= event.id %>" 
+                             data-event-type="<%= event.is_a?(Competition) ? 'competition' : 'attendance_event' %>">
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      <%= event.date.strftime('%m/%d') %>
+                      <span class="text-gray-500">(<%= %w[日 月 火 水 木 金 土][event.date.wday] %>)</span>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900"><%= event.title %></td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      <% if event.is_a?(Competition) %>
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
+                          大会
+                        </span>
+                      <% end %>
+                    </td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900"><%= event.place %></td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                      <% case event.attendance_status %>
+                      <% when 'before' %>
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
+                          出欠集計前
+                        </span>
+                      <% when 'open' %>
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                          受付中
+                        </span>
+                      <% when 'closed' %>
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
+                          受付終了
+                        </span>
+                      <% end %>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        <% else %>
+          <div class="text-center py-8">
+            <p class="text-gray-500">イベントが登録されていません</p>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <!-- 操作ボタン -->
+    <div class="flex justify-center space-x-4 mb-8">
+      <%= link_to "出欠管理に戻る", admin_attendance_path, class: "bg-gray-600 text-white px-6 py-3 rounded-md text-sm font-medium hover:bg-gray-700 transition-colors" %>
+    </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const selectAllHeaderCheckbox = document.getElementById('select-all-header');
+  const eventCheckboxes = document.querySelectorAll('.event-checkbox');
+  const bulkStatusSelect = document.getElementById('bulk-status');
+  const bulkUpdateBtn = document.getElementById('bulk-update-btn');
+  const form = document.querySelector('form');
+
+  // フィルタリング要素
+  const eventTypeFilter = document.getElementById('event-type-filter');
+  const monthFilter = document.getElementById('month-filter');
+  const yearFilter = document.getElementById('year-filter');
+  const statusFilter = document.getElementById('status-filter');
+  const resetFiltersBtn = document.getElementById('reset-filters-btn');
+  const eventRows = document.querySelectorAll('.event-row');
+
+  // フィルタリング関数
+  function applyFilters() {
+    const selectedEventType = eventTypeFilter.value;
+    const selectedMonth = monthFilter.value;
+    const selectedYear = yearFilter.value;
+    const selectedStatus = statusFilter.value;
+
+    eventRows.forEach(row => {
+      let shouldShow = true;
+
+      // イベントタイプフィルター
+      if (selectedEventType && row.dataset.eventType !== selectedEventType) {
+        shouldShow = false;
+      }
+
+      // 月フィルター
+      if (selectedMonth && row.dataset.eventMonth !== selectedMonth) {
+        shouldShow = false;
+      }
+
+      // 年フィルター
+      if (selectedYear && row.dataset.eventYear !== selectedYear) {
+        shouldShow = false;
+      }
+
+      // 出欠受付状況フィルター
+      if (selectedStatus && row.dataset.eventStatus !== selectedStatus) {
+        shouldShow = false;
+      }
+
+      // 行の表示/非表示を切り替え
+      row.style.display = shouldShow ? '' : 'none';
+    });
+
+    // フィルタリング後にチェックボックスの状態を更新
+    updateSelectAll();
+  }
+
+  // 全て選択チェックボックスの処理（フィルタリングを考慮）
+  function updateSelectAll() {
+    const visibleCheckboxes = Array.from(document.querySelectorAll('.event-checkbox')).filter(checkbox => {
+      const row = checkbox.closest('.event-row');
+      return row && row.style.display !== 'none';
+    });
+    const checkedCount = visibleCheckboxes.filter(checkbox => checkbox.checked).length;
+    const totalCount = visibleCheckboxes.length;
+    
+    selectAllHeaderCheckbox.checked = checkedCount === totalCount && totalCount > 0;
+    
+    // 一括変更ボタンの有効/無効を切り替え
+    bulkUpdateBtn.disabled = checkedCount === 0 || !bulkStatusSelect.value;
+  }
+
+  // 個別チェックボックスの処理
+  eventCheckboxes.forEach(checkbox => {
+    checkbox.addEventListener('change', updateSelectAll);
+  });
+
+  // ヘッダーの全て選択チェックボックスの処理（フィルタリングを考慮）
+  selectAllHeaderCheckbox.addEventListener('change', function() {
+    const visibleCheckboxes = Array.from(document.querySelectorAll('.event-checkbox')).filter(checkbox => {
+      const row = checkbox.closest('.event-row');
+      return row && row.style.display !== 'none';
+    });
+    visibleCheckboxes.forEach(checkbox => {
+      checkbox.checked = this.checked;
+    });
+    updateSelectAll();
+  });
+
+  // フィルター変更時の処理
+  eventTypeFilter.addEventListener('change', applyFilters);
+  monthFilter.addEventListener('change', applyFilters);
+  yearFilter.addEventListener('change', applyFilters);
+  statusFilter.addEventListener('change', applyFilters);
+
+  // フィルターリセットボタンの処理
+  resetFiltersBtn.addEventListener('click', function() {
+    eventTypeFilter.value = '';
+    monthFilter.value = '';
+    yearFilter.value = '';
+    statusFilter.value = '';
+    applyFilters();
+  });
+
+  // 一括変更の選択肢変更時の処理
+  bulkStatusSelect.addEventListener('change', function() {
+    const checkedCount = Array.from(document.querySelectorAll('.event-checkbox:checked')).filter(checkbox => {
+      const row = checkbox.closest('.event-row');
+      return row && row.style.display !== 'none';
+    }).length;
+    bulkUpdateBtn.disabled = checkedCount === 0 || !this.value;
+  });
+
+  // 一括変更ボタンの処理
+  bulkUpdateBtn.addEventListener('click', function() {
+    const selectedStatus = bulkStatusSelect.value;
+    // 表示されているチェックボックスのみを取得
+    const checkedCheckboxes = Array.from(document.querySelectorAll('.event-checkbox:checked')).filter(checkbox => {
+      const row = checkbox.closest('.event-row');
+      return row && row.style.display !== 'none';
+    });
+    
+    if (checkedCheckboxes.length === 0 || !selectedStatus) {
+      alert('変更するイベントと変更先を選択してください。');
+      return;
+    }
+
+    // ボタンを無効化（重複送信防止）
+    this.disabled = true;
+    this.textContent = '更新中...';
+
+    // 選択されたイベントのデータを準備
+    const updateData = {
+      attendance_events: {},
+      competitions: {}
+    };
+
+    checkedCheckboxes.forEach(checkbox => {
+      const eventId = checkbox.dataset.eventId;
+      const eventType = checkbox.dataset.eventType;
+      
+      if (eventType === 'competition') {
+        updateData.competitions[eventId] = selectedStatus;
+      } else {
+        updateData.attendance_events[eventId] = selectedStatus;
+      }
+    });
+
+    // AJAXでサーバーに送信
+    fetch('/admin/attendance/status', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || document.querySelector('input[name="authenticity_token"]')?.value || ''
+      },
+      body: JSON.stringify(updateData)
+    })
+    .then(response => response.json())
+    .then(data => {
+      if (data.success) {
+        // 成功：ページをリロード
+        window.location.reload();
+      } else {
+        alert('更新に失敗しました: ' + (data.message || '不明なエラー'));
+        // エラーの場合のみボタンを再度有効化
+        this.disabled = false;
+        this.textContent = '一括変更';
+      }
+    })
+    .catch(error => {
+      console.error('Fetch error:', error);
+      alert('更新に失敗しました。');
+      // エラーの場合のみボタンを再度有効化
+      this.disabled = false;
+      this.textContent = '一括変更';
+    });
+  });
+
+  // 初期状態の設定
+  updateSelectAll();
+});
+</script> 

--- a/app/views/admin/schedules/index.html.erb
+++ b/app/views/admin/schedules/index.html.erb
@@ -57,7 +57,7 @@
               <% @events.each do |event| %>
                 <tr>
                   <td class="px-6 py-4 whitespace-nowrap text-gray-900">
-                    <%= event.date.strftime('%Y/%m/%d') %>
+                    <%= event.date.strftime('%m/%d') %>
                     <span class="text-gray-900">(<%= %w[日 月 火 水 木 金 土][event.date.wday] %>)</span>
                   </td>
                   <td class="px-6 py-4 whitespace-nowrap text-gray-900"><%= event.title %></td>
@@ -170,7 +170,7 @@
 
 <!-- 編集モーダル -->
 <%= render 'shared/modal', modal_id: 'edit_schedule_modal', title: 'スケジュール編集' do %>
-  <%= form_with(url: '#', method: :patch, class: "space-y-4", id: 'edit_schedule_form') do |f| %>
+  <%= form_with(url: admin_update_schedule_path(0), method: :patch, class: "space-y-4", id: 'edit_schedule_form') do |f| %>
     <div>
       <%= f.label :title, "タイトル", class: "block text-sm font-medium text-gray-700" %>
       <%= f.text_field :title, 
@@ -249,12 +249,28 @@
 <% end %>
 
 <script>
+// CSRFトークンをグローバル変数として定義
+const csrfToken = '<%= form_authenticity_token %>';
+
 function openEditModal(button) {
   const eventId = button.dataset.eventId;
   console.log('Edit button clicked for event:', eventId);
   
   const form = document.querySelector('#edit_schedule_form');
   form.action = `/admin/schedule/${eventId}`;
+  
+  // CSRFトークンを更新
+  const csrfInput = form.querySelector('input[name="authenticity_token"]');
+  if (csrfInput) {
+    csrfInput.value = csrfToken;
+  } else {
+    // CSRFトークンのinputが存在しない場合は作成
+    const newCsrfInput = document.createElement('input');
+    newCsrfInput.type = 'hidden';
+    newCsrfInput.name = 'authenticity_token';
+    newCsrfInput.value = csrfToken;
+    form.appendChild(newCsrfInput);
+  }
   
   fetch(`/admin/schedule/${eventId}/edit`)
     .then(response => {

--- a/app/views/attendance/edit.html.erb
+++ b/app/views/attendance/edit.html.erb
@@ -8,12 +8,12 @@
 </div>
 
 <%= form_with(url: update_attendance_edit_path, method: :patch, class: "space-y-6") do |f| %>
-  <!-- 今月の出席管理フォーム -->
+  <!-- イベント一覧 -->
   <div class="bg-white rounded-lg shadow p-6">
-    <h3 class="text-xl font-semibold mb-4">今月のイベント</h3>
-    <% if @this_month_events.any? %>
+    <h3 class="text-xl font-semibold mb-4">イベント一覧（受付中・受付終了）</h3>
+    <% if @events.any? %>
       <div class="space-y-3">
-        <% @this_month_events.each do |event| %>
+        <% @events.each do |event| %>
           <div class="flex items-center gap-4 py-3 px-4 border border-gray-200 rounded-lg bg-gray-50" data-event-id="<%= event.id %>">
             <!-- 編集/保存ボタン -->
             <div class="flex-shrink-0">
@@ -26,13 +26,20 @@
               </button>
             </div>
 
-            <!-- 日付・イベント名・場所 -->
+            <!-- 日付・イベント名・場所・受付ステータス -->
             <div class="w-64 flex-shrink-0">
               <div class="text-sm font-medium"><%= event.date.strftime("%m月%d日") %>(<%= japanese_weekday(event.date) %>)</div>
               <div class="text-sm text-gray-600"><%= event.title %></div>
               <% if event.place.present? %>
                 <div class="text-xs text-gray-500">@<%= event.place %></div>
               <% end %>
+              <div class="text-xs">
+                <% if event.attendance_status == "open" %>
+                  <span class="text-green-600 font-medium">受付中</span>
+                <% elsif event.attendance_status == "closed" %>
+                  <span class="text-red-600 font-medium">受付終了</span>
+                <% end %>
+              </div>
             </div>
 
             <!-- 出席ステータス -->
@@ -81,84 +88,7 @@
         <% end %>
       </div>
     <% else %>
-      <p class="text-gray-600">今月のイベントはありません。</p>
-    <% end %>
-  </div>
-
-  <!-- 来月の出席管理フォーム -->
-  <div class="bg-white rounded-lg shadow p-6">
-    <h3 class="text-xl font-semibold mb-4">来月のイベント</h3>
-    <% if @next_month_events.any? %>
-      <div class="space-y-3">
-        <% @next_month_events.each do |event| %>
-          <div class="flex items-center gap-4 py-3 px-4 border border-gray-200 rounded-lg bg-gray-50" data-event-id="<%= event.id %>">
-            <!-- 編集/保存ボタン -->
-            <div class="flex-shrink-0">
-              <button type="button" class="edit-btn bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded text-sm transition-colors duration-200" data-event-id="<%= event.id %>">
-                編集
-              </button>
-              <!-- 保存ボタン（編集中のみ表示） -->
-              <button type="button" class="save-btn hidden bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded text-sm transition-colors duration-200" data-event-id="<%= event.id %>">
-                保存
-              </button>
-            </div>
-
-            <!-- 日付・イベント名・場所 -->
-            <div class="w-64 flex-shrink-0">
-              <div class="text-sm font-medium"><%= event.date.strftime("%m月%d日") %>(<%= japanese_weekday(event.date) %>)</div>
-              <div class="text-sm text-gray-600"><%= event.title %></div>
-              <% if event.place.present? %>
-                <div class="text-xs text-gray-500">@<%= event.place %></div>
-              <% end %>
-            </div>
-
-            <!-- 出席ステータス -->
-            <% user_attendance = @user_attendance[event.id] %>
-            <div class="flex items-center gap-6 form-controls" data-event-id="<%= event.id %>">
-              <div class="flex items-center gap-1">
-                <%= f.radio_button "attendance[#{event.id}][status]", "present", checked: user_attendance&.status == "present", class: "form-radio", data: { requires_note: false }, disabled: true %>
-                <%= f.label "attendance[#{event.id}][status]", "出席", value: "present", class: "text-sm cursor-pointer" %>
-              </div>
-
-              <div class="flex items-center gap-1">
-                <%= f.radio_button "attendance[#{event.id}][status]", "absent", checked: user_attendance&.status == "absent", class: "form-radio", data: { requires_note: true }, disabled: true %>
-                <%= f.label "attendance[#{event.id}][status]", "欠席", value: "absent", class: "text-sm cursor-pointer" %>
-              </div>
-
-              <div class="flex items-center gap-1">
-                <%= f.radio_button "attendance[#{event.id}][status]", "other", checked: user_attendance&.status == "other", class: "form-radio", data: { requires_note: true }, disabled: true %>
-                <%= f.label "attendance[#{event.id}][status]", "その他", value: "other", class: "text-sm cursor-pointer" %>
-              </div>
-            </div>
-
-            <!-- 備考欄 -->
-            <div class="flex-1">
-              <%= f.text_area "attendance[#{event.id}][note]", 
-                  value: user_attendance&.note,
-                  class: "w-full text-sm rounded border border-gray-200 px-2 py-1 h-auto resize-none", 
-                  rows: 1, 
-                  required: false, 
-                  placeholder: "欠席・その他の場合は必ず理由を入力",
-                  disabled: true %>
-            </div>
-
-            <!-- 回答状況表示 -->
-            <div class="flex-shrink-0">
-              <% if user_attendance && user_attendance.status.present? %>
-                <span class="inline-block px-2 py-1 text-xs font-semibold rounded-full bg-green-100 text-green-800">
-                  回答済み
-                </span>
-              <% else %>
-                <span class="inline-block px-2 py-1 text-xs font-semibold rounded-full bg-red-100 text-red-800">
-                  未回答
-                </span>
-              <% end %>
-            </div>
-          </div>
-        <% end %>
-      </div>
-    <% else %>
-      <p class="text-gray-600">来月のイベントはありません。</p>
+      <p class="text-gray-600">イベントはありません。</p>
     <% end %>
   </div>
 

--- a/app/views/attendance/index.html.erb
+++ b/app/views/attendance/index.html.erb
@@ -6,13 +6,13 @@
     <%= link_to "出欠情報を編集する", edit_attendance_path, class: "bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded transition duration-200", data: { turbo: false } %>
   </div>
   
-<!-- 今月の出席管理フォーム -->
+<!-- 出席管理フォーム -->
 <div class="mb-8 bg-white rounded-lg shadow p-6">
-  <h3 class="text-xl font-semibold mb-4">今月の出席管理（未回答のイベント）</h3>
-  <% if @this_month_events.any? %>
+  <h3 class="text-xl font-semibold mb-4">出席管理（受付中）</h3>
+  <% if @open_events.any? %>
     <%= form_with(url: update_attendance_path, method: :post, class: "space-y-2") do |f| %>
 
-      <% @this_month_events.each do |event| %>
+      <% @open_events.each do |event| %>
         <div class="flex items-center gap-4 py-2 px-4 border border-gray-200 rounded-lg">
           <!-- 日付・イベント名・場所 -->
           <div class="w-48 flex-shrink-0">
@@ -58,58 +58,7 @@
       </div>
     <% end %>
   <% else %>
-    <p class="text-gray-600">今月の未回答のイベントはありません。</p>
-  <% end %>
-</div>
-
-<!-- 来月の出席管理フォーム -->
-<div class="mb-8 bg-white rounded-lg shadow p-6">
-  <h3 class="text-xl font-semibold mb-4">来月の出席管理（未回答のイベント）</h3>
-  <% if @next_month_events.any? %>
-    <%= form_with(url: update_attendance_path, method: :post, class: "space-y-2") do |f| %>
-      <% @next_month_events.each do |event| %>
-        <div class="flex items-center gap-4 py-2 px-4 border border-gray-200 rounded-lg">
-          <!-- 日付・イベント名・場所 -->
-          <div class="w-48 flex-shrink-0">
-            <div class="text-sm font-medium"><%= event.date.strftime("%m月%d日") %>(<%= japanese_weekday(event.date) %>)</div>
-            <div class="text-sm text-gray-600"><%= event.title %></div>
-            <% if event.place.present? %>
-              <div class="text-xs text-gray-500">@<%= event.place %></div>
-            <% end %>
-          </div>
-
-          <!-- 出席ステータス -->
-          <% attendance = @attendance.find_by(attendance_event: event) %>
-          <div class="flex items-center gap-6">
-            <div class="flex items-center gap-1">
-              <%= f.radio_button "attendance[#{event.id}][status]", "present", checked: attendance&.status == "present", class: "form-radio", data: { requires_note: false } %>
-              <%= f.label "attendance[#{event.id}][status]", "出席", value: "present", class: "text-sm cursor-pointer" %>
-            </div>
-
-            <div class="flex items-center gap-1">
-              <%= f.radio_button "attendance[#{event.id}][status]", "absent", checked: attendance&.status == "absent", class: "form-radio", data: { requires_note: true } %>
-              <%= f.label "attendance[#{event.id}][status]", "欠席", value: "absent", class: "text-sm cursor-pointer" %>
-            </div>
-
-            <div class="flex items-center gap-1">
-              <%= f.radio_button "attendance[#{event.id}][status]", "other", checked: attendance&.status == "other", class: "form-radio", data: { requires_note: true } %>
-              <%= f.label "attendance[#{event.id}][status]", "その他（遅刻・早退など）", value: "other", class: "text-sm cursor-pointer" %>
-            </div>
-          </div>
-
-          <!-- 備考欄 -->
-          <div class="flex-1">
-            <%= f.text_area "attendance[#{event.id}][note]", value: attendance&.note, class: "w-full text-sm rounded border border-gray-200 px-2 py-1 h-8 leading-6 resize-none", rows: 1, required: false, placeholder: "欠席・その他の場合は必ず理由を入力" %>
-          </div>
-        </div>
-      <% end %>
-
-      <div class="mt-4">
-        <%= f.submit "すべての回答を保存", class: "bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700" %>
-      </div>
-    <% end %>
-  <% else %>
-    <p class="text-gray-600">来月の未回答のイベントはありません。</p>
+    <p class="text-gray-600">受付中のイベントはありません。</p>
   <% end %>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -155,6 +155,8 @@ Rails.application.routes.draw do
   get "admin/attendance/check", to: "admin/attendances#check", as: "admin_attendance_check"
   patch "admin/attendance/check", to: "admin/attendances#update_check", as: "update_admin_attendance_check"
   patch "admin/attendance/save", to: "admin/attendances#save_check", as: "save_admin_attendance_check"
+  get "admin/attendance/status", to: "admin/attendances#status", as: "admin_attendance_status"
+  patch "admin/attendance/status", to: "admin/attendances#update_status", as: "update_admin_attendance_status"
 
   # [管理者]出席状況更新
   get "admin/attendance/update", to: "admin/attendances#update", as: "admin_attendance_update"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -742,3 +742,28 @@ end
 
 puts "エントリーデータの作成が完了しました"
 puts "作成されたエントリー数: #{Entry.count}"
+
+# 過去のイベントの出欠受付とエントリーを自動的に終了
+puts "過去のイベントの出欠受付とエントリーを終了しています..."
+today = Date.current
+
+# 過去のAttendanceEventを全てclosedに更新
+past_attendance_events = AttendanceEvent.where("date < ? AND attendance_status != ?", today, 2)
+attendance_events_count = past_attendance_events.count
+past_attendance_events.update_all(attendance_status: 2)
+
+# 過去のCompetitionを全てclosedに更新（出欠受付）
+past_competitions = Competition.where("date < ? AND attendance_status != ?", today, 2)
+competitions_count = past_competitions.count
+past_competitions.update_all(attendance_status: 2)
+
+# 過去のCompetitionのエントリーを全てclosedに更新
+past_competitions_entry = Competition.where("date < ? AND entry_status != ?", today, 2)
+competitions_entry_count = past_competitions_entry.count
+past_competitions_entry.update_all(entry_status: 2)
+
+total_attendance_count = attendance_events_count + competitions_count
+puts "過去のイベントの出欠受付を終了しました: #{total_attendance_count}件"
+puts "  - AttendanceEvent: #{attendance_events_count}件"
+puts "  - Competition: #{competitions_count}件"
+puts "過去の大会のエントリーを終了しました: #{competitions_entry_count}件"

--- a/lib/tasks/close_past_events.rake
+++ b/lib/tasks/close_past_events.rake
@@ -1,0 +1,29 @@
+namespace :close_past_events do
+  desc "過去のイベントの出欠受付とエントリーを自動的に終了する"
+  task close_past_events: :environment do
+    puts "過去のイベントの出欠受付とエントリーを終了しています..."
+    
+    today = Date.current
+    
+    # 過去のAttendanceEventを全てclosedに更新
+    past_attendance_events = AttendanceEvent.where("date < ? AND attendance_status != ?", today, 2)
+    attendance_events_count = past_attendance_events.count
+    past_attendance_events.update_all(attendance_status: 2)
+    
+    # 過去のCompetitionを全てclosedに更新（出欠受付）
+    past_competitions = Competition.where("date < ? AND attendance_status != ?", today, 2)
+    competitions_count = past_competitions.count
+    past_competitions.update_all(attendance_status: 2)
+    
+    # 過去のCompetitionのエントリーを全てclosedに更新
+    past_competitions_entry = Competition.where("date < ? AND entry_status != ?", today, 2)
+    competitions_entry_count = past_competitions_entry.count
+    past_competitions_entry.update_all(entry_status: 2)
+    
+    total_attendance_count = attendance_events_count + competitions_count
+    puts "完了: #{total_attendance_count}件の過去イベントの出欠受付を終了しました"
+    puts "  - AttendanceEvent: #{attendance_events_count}件"
+    puts "  - Competition: #{competitions_count}件"
+    puts "完了: #{competitions_entry_count}件の過去大会のエントリーを終了しました"
+  end
+end 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 管理者向けに出欠受付管理ページを追加し、イベントの受付状態を一括更新・フィルタリングできるようになりました。
  * 過去イベントの出欠・エントリー受付状態を自動で「受付終了」にする管理用Rakeタスクとシード処理を追加しました。

* **改善**
  * 出欠管理画面を「受付中」のイベントのみ表示する形に統合し、操作性を向上しました。
  * 出欠編集画面のレイアウトを簡素化し、イベント情報と受付状態のみ表示するよう変更しました。
  * 管理者スケジュール一覧の日付表示を短縮形式に変更しました。

* **スタイル**
  * 管理者出欠一覧テーブルのレイアウト・見やすさを改善しました。

* **バグ修正**
  * 出欠メモの編集時刻付与条件を「受付終了」時のみに修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->